### PR TITLE
feat: add cache and circuit breaker helpers + exports

### DIFF
--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -1,0 +1,84 @@
+// Instance-based cache with optional TTL and LRU eviction.
+// Small, dependency-free helper to complement macrofx macros.
+
+export type Cache<K, V> = {
+  readonly get: (key: K) => V | undefined;
+  readonly set: (key: K, value: V, ttlMs?: number) => void;
+  readonly invalidateKey: (key: K) => void;
+  readonly invalidateWhere: (predicate: (key: K, value: V) => boolean) => void;
+  readonly clear: () => void;
+};
+
+type Entry<V> = {
+  v: V;
+  exp?: number; // expiry timestamp (ms since epoch)
+  at: number; // last accessed timestamp (for LRU)
+};
+
+export const createCache = <K, V>(opts?: {
+  maxSize?: number; // LRU max size (default: 1000)
+  defaultTtlMs?: number; // default TTL for set() without explicit ttlMs
+}): Cache<K, V> => {
+  const maxSize = Math.max(1, opts?.maxSize ?? 1000);
+  const defaultTtlMs = opts?.defaultTtlMs;
+  const map = new Map<K, Entry<V>>();
+
+  const now = () => Date.now();
+
+  const isExpired = (e: Entry<V>): boolean =>
+    typeof e.exp === "number" && now() > e.exp;
+
+  const updateAccess = (e: Entry<V>) => {
+    e.at = now();
+  };
+
+  const evictLRU = () => {
+    if (map.size <= maxSize) return;
+    let lruKey: K | undefined;
+    let lruAt = Infinity;
+    for (const [k, e] of map.entries()) {
+      if (e.at < lruAt) {
+        lruAt = e.at;
+        lruKey = k;
+      }
+    }
+    if (typeof lruKey !== "undefined") map.delete(lruKey);
+  };
+
+  const get = (key: K): V | undefined => {
+    const e = map.get(key);
+    if (!e) return undefined;
+    if (isExpired(e)) {
+      map.delete(key);
+      return undefined;
+    }
+    updateAccess(e);
+    return e.v;
+  };
+
+  const set = (key: K, value: V, ttlMs?: number): void => {
+    const exp = typeof (ttlMs ?? defaultTtlMs) === "number"
+      ? now() + (ttlMs ?? defaultTtlMs!)
+      : undefined;
+    const e: Entry<V> = { v: value, exp, at: now() };
+    map.set(key, e);
+    // simple single-step eviction (good enough in practice)
+    if (map.size > maxSize) evictLRU();
+  };
+
+  const invalidateKey = (key: K): void => {
+    map.delete(key);
+  };
+
+  const invalidateWhere = (predicate: (key: K, value: V) => boolean): void => {
+    for (const [k, e] of map.entries()) {
+      if (predicate(k, e.v)) map.delete(k);
+    }
+  };
+
+  const clear = (): void => {
+    map.clear();
+  };
+
+  return { get, set, invalidateKey, invalidateWhere, clear } as const;
+};

--- a/lib/circuit_breaker.ts
+++ b/lib/circuit_breaker.ts
@@ -1,0 +1,89 @@
+// Simple circuit breaker helper with closed/open/half_open states.
+// Use to guard flaky operations. Complements retry/timeout helpers.
+
+export type CircuitBreaker = {
+  readonly allow: () => boolean;
+  readonly onSuccess: () => void;
+  readonly onFailure: () => void;
+  readonly state: () => "closed" | "open" | "half_open";
+  readonly wrap: <T>(fn: () => Promise<T>) => Promise<T>;
+};
+
+export const createCircuitBreaker = (
+  fails: number,
+  resetMs: number,
+): CircuitBreaker => {
+  const threshold = Math.max(1, Math.floor(fails));
+  const reset = Math.max(1, Math.floor(resetMs));
+
+  let failureCount = 0;
+  let openedAt = 0;
+  let halfProbeInFlight = false;
+  let mode: "closed" | "open" | "half_open" = "closed";
+
+  const now = () => Date.now();
+
+  const allow = (): boolean => {
+    if (mode === "closed") return true;
+    if (mode === "open") {
+      if (now() - openedAt >= reset) {
+        mode = "half_open";
+        halfProbeInFlight = false;
+      } else {
+        return false;
+      }
+    }
+    // half_open: allow a single probe at a time
+    if (mode === "half_open") {
+      if (halfProbeInFlight) return false;
+      halfProbeInFlight = true;
+      return true;
+    }
+    return false;
+  };
+
+  const onSuccess = (): void => {
+    if (mode === "half_open") {
+      mode = "closed";
+      halfProbeInFlight = false;
+    }
+    // On success, reset failure counter
+    failureCount = 0;
+  };
+
+  const onFailure = (): void => {
+    if (mode === "half_open") {
+      // Probe failed -> open again
+      mode = "open";
+      openedAt = now();
+      halfProbeInFlight = false;
+      failureCount = 0;
+      return;
+    }
+    if (mode === "closed") {
+      failureCount++;
+      if (failureCount >= threshold) {
+        mode = "open";
+        openedAt = now();
+        failureCount = 0;
+      }
+    }
+  };
+
+  const wrap = async <T>(fn: () => Promise<T>): Promise<T> => {
+    if (!allow()) throw new Error("circuit_breaker: open");
+    try {
+      const v = await fn();
+      onSuccess();
+      return v;
+    } catch (e) {
+      onFailure();
+      throw e;
+    }
+  };
+
+  return { allow, onSuccess, onFailure, state: () => mode, wrap } as const;
+};
+
+export const runWithCircuitBreaker = <T>(br: CircuitBreaker, fn: () => Promise<T>) =>
+  br.wrap(fn);

--- a/mod.ts
+++ b/mod.ts
@@ -11,3 +11,6 @@ export * from "./macros/retry.ts";
 export * from "./macros/timeout.ts";
 export * from "./macros/sink.ts";
 export * from "./macros/schema.ts";
+
+export * from "./lib/cache.ts";
+export * from "./lib/circuit_breaker.ts";

--- a/tests/cache.test.ts
+++ b/tests/cache.test.ts
@@ -1,0 +1,43 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { createCache } from "../lib/cache.ts";
+
+Deno.test("cache: set/get/invalidate", () => {
+  const c = createCache<string, number>({ maxSize: 10 });
+  assertEquals(c.get("a"), undefined);
+  c.set("a", 1);
+  assertEquals(c.get("a"), 1);
+  c.invalidateKey("a");
+  assertEquals(c.get("a"), undefined);
+});
+
+Deno.test("cache: ttl expiry", async () => {
+  const c = createCache<string, number>({ defaultTtlMs: 10 });
+  c.set("x", 42);
+  assertEquals(c.get("x"), 42);
+  await new Promise((r) => setTimeout(r, 15));
+  assertEquals(c.get("x"), undefined);
+});
+
+Deno.test("cache: LRU eviction", () => {
+  const c = createCache<string, number>({ maxSize: 2 });
+  c.set("a", 1);
+  c.set("b", 2);
+  // Access "a" to make it recently used
+  assertEquals(c.get("a"), 1);
+  // Insert "c" -> should evict least-recently-used ("b")
+  c.set("c", 3);
+  assertEquals(c.get("b"), undefined);
+  assertEquals(c.get("a"), 1);
+  assertEquals(c.get("c"), 3);
+});
+
+Deno.test("cache: invalidateWhere", () => {
+  const c = createCache<string, number>({ maxSize: 5 });
+  c.set("user:1", 1);
+  c.set("user:2", 2);
+  c.set("post:1", 10);
+  c.invalidateWhere((k) => k.startsWith("user:"));
+  assertEquals(c.get("user:1"), undefined);
+  assertEquals(c.get("user:2"), undefined);
+  assertEquals(c.get("post:1"), 10);
+});

--- a/tests/circuit_breaker.test.ts
+++ b/tests/circuit_breaker.test.ts
@@ -1,0 +1,30 @@
+import { assertEquals, assertRejects } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { createCircuitBreaker } from "../lib/circuit_breaker.ts";
+
+Deno.test("breaker: opens after threshold of failures", async () => {
+  const br = createCircuitBreaker(2, 50);
+
+  await assertRejects(() => br.wrap(async () => { throw new Error("x"); }));
+  await assertRejects(() => br.wrap(async () => { throw new Error("x"); }));
+
+  assertEquals(br.state(), "open");
+
+  // While open, wrap should reject immediately
+  await assertRejects(() => br.wrap(async () => 1));
+});
+
+Deno.test("breaker: half-open then closed after success", async () => {
+  const br = createCircuitBreaker(1, 30);
+
+  // Trigger open
+  await assertRejects(() => br.wrap(async () => { throw new Error("x"); }));
+  assertEquals(br.state(), "open");
+
+  // Wait reset -> half_open
+  await new Promise((r) => setTimeout(r, 35));
+
+  // First probe succeeds -> closed
+  const v = await br.wrap(async () => 123);
+  assertEquals(v, 123);
+  assertEquals(br.state(), "closed");
+});


### PR DESCRIPTION
This PR adds small helpers that complement macrofx macros and align with Light FP usage patterns:

- lib/cache.ts
  - createCache<K,V> with optional TTL and LRU eviction
  - Cache<K,V> interface with get/set/invalidateKey/invalidateWhere/clear
- lib/circuit_breaker.ts
  - createCircuitBreaker(fails, resetMs) with closed/open/half_open states
  - runWithCircuitBreaker helper for convenience
- mod.ts
  - exports for ./lib/cache.ts and ./lib/circuit_breaker.ts
- tests
  - tests/cache.test.ts: set/get/ttl/lru/invalidateWhere
  - tests/circuit_breaker.test.ts: opens after failures; half-open then closed on success

Rationale:
- Keeps side-effect helpers small and composable, matching macrofx style (similar to runWithRetry)
- Unblocks dependent projects (e.g., Light-FP Author) from maintaining local adapters
- Maintains strict typing; zero dependencies

If you prefer, I can split cache and breaker into separate PRs. Once merged, I'll pin Light-FP Author to the new tag and re-run end-to-end tests.


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author